### PR TITLE
Add Route.extend() for custom chainable matcher shortcuts (v8.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 8.6.0 (2026-07-29)
+
+### Added
+- `route.extend(...)`: add named, chainable matcher shortcuts to a route. The helpers survive chaining with the built-in `matching*` methods and are fully typed in TypeScript (new exported types `ExtendedRoute` and `RouteExtender`). See the "Custom matcher shortcuts" section in the README.
+
 ## 8.5.0 (2026-07-29)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -256,7 +256,11 @@ myServer.endpoint
 
 Notes:
 - `extend` can be called repeatedly; later extensions can use the earlier helpers.
-- A helper name that conflicts with an existing route member (like `handleNext`) throws an error.
+- The extender function runs again for every derived route — keep it pure (no side effects).
+  Create derived routes only inside the returned helpers; calling `matching*` or `extend`
+  in the extender body itself throws an error.
+- A helper name that conflicts with an existing route member (like `handleNext`) or with an
+  earlier extension throws an error.
 - In TypeScript, the helpers and the chaining are fully typed (see the `ExtendedRoute` and `RouteExtender` exported types).
 
 ## Failed checks

--- a/README.md
+++ b/README.md
@@ -217,6 +217,48 @@ describe('testedProcedure', () => {
 });
 ```
 
+## Custom matcher shortcuts: `extend`
+
+When the same matcher appears in many tests, give it a name with `extend`. It returns a new route
+with your helper methods added; the original route is not changed.
+
+```javascript
+class SomeService extends MockServer {
+
+    constructor () {
+        super(3000);
+
+        this.endpoint = this.post('/somePath/:id', (ctx) => {
+            ctx.body = { message: 'default response' };
+        }).extend((route) => ({
+            withId (id) {
+                return route.matchingParam('id', id);
+            },
+            authorizedBy (token) {
+                return route.matchingHeader('Authorization', `Bearer ${token}`);
+            },
+        }));
+    }
+
+}
+```
+
+The helpers stay chainable — with the built-in matchers and with each other:
+
+```javascript
+myServer.endpoint
+    .withId(42)
+    .authorizedBy('myToken')
+    .matchingBody({ some: 'property' }) // built-in matchers still work
+    .withId(42)                         // ...and your helpers stay available after them
+    .handleNext();
+```
+
+Notes:
+- `extend` can be called repeatedly; later extensions can use the earlier helpers.
+- A helper name that conflicts with an existing route member (like `handleNext`) throws an error.
+- In TypeScript, the helpers and the chaining are fully typed (see the `ExtendedRoute` and `RouteExtender` exported types).
+
 ## Failed checks
 
 When a one-time handler is not called (or a `notReceive()` check fails), the test fails automatically after it finishes. If several checks fail within one test, they are reported together as an `AggregateError`.

--- a/README.md
+++ b/README.md
@@ -256,9 +256,9 @@ myServer.endpoint
 
 Notes:
 - `extend` can be called repeatedly; later extensions can use the earlier helpers.
-- The extender function runs again for every derived route — keep it pure (no side effects).
-  Create derived routes only inside the returned helpers; calling `matching*` or `extend`
-  in the extender body itself throws an error.
+- The extender function runs again for every derived route — keep it pure (no side effects)
+  and synchronous (an async extender throws). Create derived routes only inside the returned
+  helpers; calling `matching*` or `extend` in the extender body itself throws an error.
 - A helper name that conflicts with an existing route member (like `handleNext`) or with an
   earlier extension throws an error.
 - In TypeScript, the helpers and the chaining are fully typed (see the `ExtendedRoute` and `RouteExtender` exported types).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mocked-server",
-  "version": "8.5.0",
+  "version": "8.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mocked-server",
-      "version": "8.5.0",
+      "version": "8.6.0",
       "license": "MIT",
       "dependencies": {
         "@koa/router": "^13.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocked-server",
-  "version": "8.5.0",
+  "version": "8.6.0",
   "description": "Utility for mocking remote APIs servers for testing purposes",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/Route.ts
+++ b/src/Route.ts
@@ -71,12 +71,23 @@ export class Route {
             } finally {
                 applyingExtender = false;
             }
+            if (extension === null || typeof extension !== 'object') {
+                throw new Error('An extender must return an object with the extension properties.');
+            }
+            if (typeof (extension as { then?: unknown }).then === 'function') {
+                throw new Error('An extender must return the extension object synchronously; async extenders are not supported.');
+            }
             for (const key of Reflect.ownKeys(extension)) {
+                if (key === '__proto__') {
+                    throw new Error('Extension property "__proto__" is not allowed.');
+                }
                 if (this._hasConflictingMember(key)) {
                     throw new Error(`Extension property "${String(key)}" conflicts with an existing Route member or an earlier extension.`);
                 }
             }
-            Object.assign(this, extension);
+            // descriptor-based copy keeps accessors and non-enumerable properties intact,
+            // which Object.assign would evaluate or silently skip
+            Object.defineProperties(this, Object.getOwnPropertyDescriptors(extension));
         }
     }
 

--- a/src/Route.ts
+++ b/src/Route.ts
@@ -15,6 +15,19 @@ import { mapKeys, isMatchWith, isFunction, isRegExp } from 'lodash';
 import { MockServer } from "./MockServer";
 import { Context, Middleware } from 'koa';
 
+export type RouteExtender<X extends object = object> = (route: Route) => X;
+
+/**
+ * The type of a route returned by Route.extend(): the route itself plus the extension.
+ * Extension methods that return a Route are re-typed to return the extended route,
+ * so custom helpers stay chainable.
+ */
+export type ExtendedRoute<R extends Route, X> = R & {
+    [K in keyof X]: X[K] extends (...args: infer A) => infer Ret
+        ? Ret extends Route ? (...args: A) => ExtendedRoute<R, X> : X[K]
+        : X[K];
+};
+
 
 function testMatch (tested: Record<any, any>, template: TemplateMatcher, expectStrings: boolean): boolean {
     return isMatchWith(tested, template, (currentValue: any, expectedValue: any) => {
@@ -39,21 +52,47 @@ export class Route {
         private _mockServer: MockServer,
         private _method: Method,
         private _path: Path,
-        private _matchers: MatcherFunction[] = []
-    ) {}
+        private _matchers: MatcherFunction[] = [],
+        private _extenders: RouteExtender[] = []
+    ) {
+        for (const extender of this._extenders) {
+            const extension = extender(this);
+            for (const key of Object.keys(extension)) {
+                if (key in this) {
+                    throw new Error(`Extension property "${key}" conflicts with an existing Route member.`);
+                }
+            }
+            Object.assign(this, extension);
+        }
+    }
 
+    /**
+     * Every derived Route goes through here so registered extenders are re-applied
+     * (in the constructor) and custom extension methods survive chaining.
+     */
+    private _derive (matchers: MatcherFunction[], extenders: RouteExtender[]): this {
+        return new Route(this._mockServer, this._method, this._path, matchers, extenders) as this;
+    }
 
+    /**
+     * Returns a new Route extended with custom properties (typically chainable matcher shortcuts).
+     * The extension survives chaining: routes derived via 'matching*' methods keep the custom methods.
+     * An extension property whose name conflicts with an existing Route member throws.
+     */
+    extend <X extends object>(extender: (route: this) => X): ExtendedRoute<this, X> {
+        // the `this`-typed parameter is safe here (extenders always receive the route they extend),
+        // but it is contravariant to RouteExtender's Route parameter, hence the double cast
+        const storableExtender = extender as unknown as RouteExtender;
+        return this._derive(this._matchers, [...this._extenders, storableExtender]) as ExtendedRoute<this, X>;
+    }
 
     /**
      * Returns a customized Route instance, which will match only requests for which the Matcher function returns true
      */
-    matching (matcher: Matcher): Route {
+    matching (matcher: Matcher): this {
 
         if (isFunction(matcher)) {
-            return new Route(this._mockServer, this._method, this._path, [
-                ...this._matchers,
-                matcher
-            ]);
+            return this._derive([...this._matchers, matcher], this._extenders);
         }
 
         const validProps: MatcherProp[] = ['params', 'query', 'body', 'headers'];
@@ -81,41 +120,41 @@ export class Route {
                 return prev.matchingBody(matcher[prop]!);
             }
             throw new Error('This cannot happen.');
-        }, this);
+        }, this) as this;
     }
 
     /**
      * Returns a customized Route instance, which will match only requests with the path params specified
      */
-    matchingParams (matcher: TemplateMatcher): Route {
+    matchingParams (matcher: TemplateMatcher): this {
         return this.matching((ctx) => testMatch(ctx.params, matcher, true));
     }
 
     /**
      * Returns a customized Route instance, which will match only requests with the path param specified
      */
-    matchingParam (param: string, value: ValueToMatch): Route {
+    matchingParam (param: string, value: ValueToMatch): this {
         return this.matchingParams({ [param]: value });
     }
 
     /**
      * Returns a customized Route instance, which will match only requests with the query params specified
      */
-    matchingQuery (matcher: TemplateMatcher): Route {
+    matchingQuery (matcher: TemplateMatcher): this {
         return this.matching((ctx) => testMatch(ctx.query, matcher, true));
     }
 
     /**
      * Returns a customized Route instance, which will match only requests with the query params specified
      */
-    matchingQueryParam (param: string, value: ValueToMatch): Route {
+    matchingQueryParam (param: string, value: ValueToMatch): this {
         return this.matchingQuery({ [param]: value });
     }
 
     /**
      * Returns a customized Route instance, which will match only requests with the matching headers
      */
-    matchingHeaders (matcher: TemplateMatcher): Route {
+    matchingHeaders (matcher: TemplateMatcher): this {
         matcher = mapKeys(matcher, (value: any, key: any) => `${key}`.toLowerCase());
         return this.matching((ctx) => testMatch(ctx.headers, matcher, true));
     }
@@ -123,14 +162,14 @@ export class Route {
     /**
      * Returns a customized Route instance, which will match only requests with the matching headers
      */
-    matchingHeader (header: string, value: ValueToMatch): Route {
+    matchingHeader (header: string, value: ValueToMatch): this {
         return this.matchingHeaders({ [header]: value });
     }
 
     /**
      * Returns a customized Route instance, which will match only requests with the matching body
      */
-    matchingBody (matcher: TemplateMatcher): Route {
+    matchingBody (matcher: TemplateMatcher): this {
         return this.matching((ctx) => testMatch(ctx.request.body, matcher, false));
     }
 

--- a/src/Route.ts
+++ b/src/Route.ts
@@ -19,14 +19,18 @@ export type RouteExtender<X extends object = object> = (route: Route) => X;
 
 /**
  * The type of a route returned by Route.extend(): the route itself plus the extension.
- * Extension methods that return a Route are re-typed to return the extended route,
- * so custom helpers stay chainable.
+ * Extension methods that return a Route are re-typed to return the receiver's own type,
+ * so custom helpers stay chainable — even across stacked extend() calls.
  */
 export type ExtendedRoute<R extends Route, X> = R & {
     [K in keyof X]: X[K] extends (...args: infer A) => infer Ret
-        ? Ret extends Route ? (...args: A) => ExtendedRoute<R, X> : X[K]
+        ? Ret extends Route ? <Self extends Route>(this: Self, ...args: A) => Self : X[K]
         : X[K];
 };
+
+// guards against infinite recursion: an extender body deriving a route (matching*/extend)
+// would re-apply the same extender on the derived route, forever
+let applyingExtender = false;
 
 
 function testMatch (tested: Record<any, any>, template: TemplateMatcher, expectStrings: boolean): boolean {
@@ -56,10 +60,20 @@ export class Route {
         private _extenders: RouteExtender[] = []
     ) {
         for (const extender of this._extenders) {
-            const extension = extender(this);
-            for (const key of Object.keys(extension)) {
-                if (key in this) {
-                    throw new Error(`Extension property "${key}" conflicts with an existing Route member.`);
+            if (applyingExtender) {
+                throw new Error('Cannot derive a route while an extender is being applied.'
+                    + ' Call matching*/extend inside the returned helper methods, not in the extender body itself.');
+            }
+            applyingExtender = true;
+            let extension: object;
+            try {
+                extension = extender(this);
+            } finally {
+                applyingExtender = false;
+            }
+            for (const key of Reflect.ownKeys(extension)) {
+                if (this._hasConflictingMember(key)) {
+                    throw new Error(`Extension property "${String(key)}" conflicts with an existing Route member or an earlier extension.`);
                 }
             }
             Object.assign(this, extension);
@@ -67,11 +81,29 @@ export class Route {
     }
 
     /**
+     * A conflict is an own property (a private field or an earlier extension) or a member
+     * found on the prototype chain before Object.prototype — inherited Object members
+     * like toString may be overridden by an extension.
+     */
+    private _hasConflictingMember (key: PropertyKey): boolean {
+        if (Object.prototype.hasOwnProperty.call(this, key)) {
+            return true;
+        }
+        for (let proto = Object.getPrototypeOf(this); proto && proto !== Object.prototype; proto = Object.getPrototypeOf(proto)) {
+            if (Object.prototype.hasOwnProperty.call(proto, key)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Every derived Route goes through here so registered extenders are re-applied
      * (in the constructor) and custom extension methods survive chaining.
      */
     private _derive (matchers: MatcherFunction[], extenders: RouteExtender[]): this {
-        return new Route(this._mockServer, this._method, this._path, matchers, extenders) as this;
+        const RouteClass = this.constructor as typeof Route;
+        return new RouteClass(this._mockServer, this._method, this._path, matchers, extenders) as this;
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 import { MockServer } from "./MockServer";
 export default MockServer;
 export { MockServer } from "./MockServer";
-export { Route } from "./Route";
+export { Route, ExtendedRoute, RouteExtender } from "./Route";
 export {
     AwaitableChecker,
     Checker,

--- a/test/MockedServer.js
+++ b/test/MockedServer.js
@@ -388,7 +388,7 @@ describe('extend', () => {
         }));
 
         endpoint
-            .matchingQueryParam('flag', 'on')
+            .matching({ query: { flag: 'on' } }) // object form derives too
             .matchResourceId(99) // still available after a built-in matcher
             .handleNext((ctx) => {
                 ctx.status = 202;
@@ -438,11 +438,29 @@ describe('extend', () => {
     it('should reject an extension property conflicting with an existing member', () => {
         assert.throws(
             () => mockApi.generalEndpoint.extend(() => ({ handleNext () {} })),
-            /Extension property "handleNext" conflicts with an existing Route member./
+            /Extension property "handleNext" conflicts with an existing Route member or an earlier extension./
         );
         assert.throws(
             () => mockApi.generalEndpoint.extend(() => ({ _matchers: [] })),
-            /Extension property "_matchers" conflicts with an existing Route member./
+            /Extension property "_matchers" conflicts with an existing Route member or an earlier extension./
+        );
+        assert.throws(
+            () => mockApi.generalEndpoint
+                .extend(() => ({ customHelper () {} }))
+                .extend(() => ({ customHelper () {} })), // same name in a later extension
+            /Extension property "customHelper" conflicts with an existing Route member or an earlier extension./
+        );
+        // inherited Object members do not count as conflicts and may be overridden
+        const labeled = mockApi.generalEndpoint.extend(() => ({ toString: () => 'my endpoint' }));
+        assert.strictEqual(`${labeled}`, 'my endpoint');
+    });
+
+    it('should reject deriving a route inside the extender body', () => {
+        assert.throws(
+            () => mockApi.generalEndpoint.extend((route) => ({
+                narrowed: route.matchingParam('resourceId', 1) // deriving eagerly would recurse forever
+            })),
+            /Cannot derive a route while an extender is being applied/
         );
     });
 

--- a/test/MockedServer.js
+++ b/test/MockedServer.js
@@ -357,6 +357,97 @@ describe('handleNext', () => {
 });
 
 
+describe('extend', () => {
+
+    it('should provide custom chainable matcher shortcuts', async () => {
+
+        const endpoint = mockApi.generalEndpoint.extend((route) => ({
+            matchResourceId (resourceId) {
+                return route.matchingParam('resourceId', resourceId);
+            }
+        }));
+
+        endpoint.matchResourceId(99).handleNext((ctx) => {
+            ctx.status = 202;
+            ctx.body = 'onetimeHandler2';
+        });
+
+        await request.get('/general-endpoint')
+            .expect(200, { endpoint: 1 });
+
+        await request.get('/general-endpoint/99')
+            .expect(202, 'onetimeHandler2');
+    });
+
+    it('should keep custom methods available after built-in matchers (chaining)', async () => {
+
+        const endpoint = mockApi.generalEndpoint.extend((route) => ({
+            matchResourceId (resourceId) {
+                return route.matchingParam('resourceId', resourceId);
+            }
+        }));
+
+        endpoint
+            .matchingQueryParam('flag', 'on')
+            .matchResourceId(99) // still available after a built-in matcher
+            .handleNext((ctx) => {
+                ctx.status = 202;
+                ctx.body = 'onetimeHandler2';
+            });
+
+        await request.get('/general-endpoint/99')
+            .expect(200, { endpoint: 1 }); // query does not match
+
+        await request.get('/general-endpoint/99?flag=on')
+            .expect(202, 'onetimeHandler2');
+    });
+
+    it('should combine matchers from stacked extends', async () => {
+
+        const endpoint = mockApi.generalEndpoint
+            .extend((route) => ({
+                matchResourceId (resourceId) {
+                    return route.matchingParam('resourceId', resourceId);
+                }
+            }))
+            .extend((route) => ({
+                matchAuthorized () {
+                    return route.matchingHeader('authorization', 'token-1');
+                }
+            }));
+
+        endpoint.matchResourceId(99).matchAuthorized().handleNext((ctx) => {
+            ctx.status = 202;
+            ctx.body = 'onetimeHandler2';
+        });
+
+        await request.get('/general-endpoint/99')
+            .expect(200, { endpoint: 1 }); // header missing
+
+        await request.get('/general-endpoint/99')
+            .set({ Authorization: 'token-1' })
+            .expect(202, 'onetimeHandler2');
+    });
+
+    it('should not modify the original route', () => {
+        const endpoint = mockApi.generalEndpoint.extend(() => ({ customHelper () {} }));
+        assert.strictEqual(typeof endpoint.customHelper, 'function');
+        assert.strictEqual(typeof mockApi.generalEndpoint.customHelper, 'undefined');
+    });
+
+    it('should reject an extension property conflicting with an existing member', () => {
+        assert.throws(
+            () => mockApi.generalEndpoint.extend(() => ({ handleNext () {} })),
+            /Extension property "handleNext" conflicts with an existing Route member./
+        );
+        assert.throws(
+            () => mockApi.generalEndpoint.extend(() => ({ _matchers: [] })),
+            /Extension property "_matchers" conflicts with an existing Route member./
+        );
+    });
+
+});
+
 describe('notReceive', () => {
 
     it('should fail when any request came to the endpoint', async () => {

--- a/test/MockedServer.js
+++ b/test/MockedServer.js
@@ -464,6 +464,32 @@ describe('extend', () => {
         );
     });
 
+    it('should reject invalid extender results', () => {
+        assert.throws(
+            () => mockApi.generalEndpoint.extend(() => null),
+            /An extender must return an object with the extension properties./
+        );
+        assert.throws(
+            () => mockApi.generalEndpoint.extend(async () => ({ helper () {} })),
+            /An extender must return the extension object synchronously; async extenders are not supported./
+        );
+        assert.throws(
+            // an object literal { __proto__: ... } would not create an own key; JSON.parse does
+            () => mockApi.generalEndpoint.extend(() => JSON.parse('{ "__proto__": { "polluted": true } }')),
+            /Extension property "__proto__" is not allowed./
+        );
+        assert.strictEqual(Object.getPrototypeOf(mockApi.generalEndpoint).polluted, undefined);
+    });
+
+    it('should preserve accessor extension properties', () => {
+        let counter = 0;
+        const endpoint = mockApi.generalEndpoint.extend(() => ({
+            get callCount () { return ++counter; }
+        }));
+        assert.strictEqual(endpoint.callCount, 1); // the getter itself is copied, not its value
+        assert.strictEqual(endpoint.matchingParam('resourceId', 1).callCount, 2); // and survives derivation
+    });
+
 });
 
 describe('notReceive', () => {

--- a/test/types/check.ts
+++ b/test/types/check.ts
@@ -25,6 +25,19 @@ extended.matchResourceId(1).matchingQueryParam('flag', 'on').matchResourceId(2).
 const description: string = extended.describePath();
 void description;
 
+// stacked extends: helpers from both levels stay chainable in any order,
+// and a later extender can use the earlier helpers
+const stacked = extended.extend((r) => ({
+    matchAuthorized () {
+        return r.matchingHeader('authorization', 'token');
+    },
+    matchAuthorizedResource (resourceId: number) {
+        return r.matchResourceId(resourceId).matchingHeader('authorization', 'token');
+    },
+}));
+stacked.matchResourceId(1).matchAuthorized().matchingParam('id', 2).matchResourceId(3).handleNext();
+stacked.matchAuthorizedResource(1).matchResourceId(2).notReceive();
+
 // the helper types are exported
 const namedExtender: RouteExtender<{ helper (): Route }> = (r) => ({ helper: () => r });
 declare const namedExtended: ExtendedRoute<Route, { helper (): Route }>;

--- a/test/types/check.ts
+++ b/test/types/check.ts
@@ -1,7 +1,7 @@
 /**
  * Compile-only checks of the published typings; run via `npm run test:types`.
  */
-import MockServerDefault, { MockServer, MockServerOptions, Route } from '../../dist';
+import MockServerDefault, { ExtendedRoute, MockServer, MockServerOptions, Route, RouteExtender } from '../../dist';
 import { Context } from 'koa';
 
 declare const route: Route;
@@ -11,6 +11,25 @@ route.matching({ query: { a: 1 } });
 route.matching({ body: { nested: /pattern/ } });
 route.matching({ params: { id: '1' }, headers: { authorization: (value: any) => value === 'token' } });
 route.matching((ctx: Context) => ctx.path === '/x');
+
+// extend(): custom helpers are typed and stay chainable with built-in matchers
+const extended = route.extend((r) => ({
+    matchResourceId (resourceId: number) {
+        return r.matchingParam('resourceId', resourceId);
+    },
+    describePath (): string {
+        return 'just a non-Route helper';
+    },
+}));
+extended.matchResourceId(1).matchingQueryParam('flag', 'on').matchResourceId(2).handleNext();
+const description: string = extended.describePath();
+void description;
+
+// the helper types are exported
+const namedExtender: RouteExtender<{ helper (): Route }> = (r) => ({ helper: () => r });
+declare const namedExtended: ExtendedRoute<Route, { helper (): Route }>;
+namedExtended.helper().matchingParam('id', 1).helper();
+void namedExtender;
 
 const options: MockServerOptions = { testRunner: 'none' };
 const server = new MockServer(3000, options);


### PR DESCRIPTION
Finalizes the idea from the old WIP branch in #139 and supersedes it.

## What

`route.extend(...)` adds named, chainable matcher shortcuts to a route:

```javascript
this.endpoint = this.post('/somePath/:id', defaultHandler).extend((route) => ({
    withId (id) { return route.matchingParam('id', id); },
    authorizedBy (token) { return route.matchingHeader('Authorization', `Bearer ${token}`); },
}));

myServer.endpoint.withId(42).matchingBody({ some: 'property' }).authorizedBy('myToken').handleNext();
```

The helpers survive chaining — this was the unsolved problem in the #139 WIP:

- **Runtime:** every derived route re-applies the registered extenders, so custom methods exist on routes produced by the built-in `matching*` methods (and by other helpers).
- **TypeScript:** the built-in `matching*` methods now return the polymorphic `this` type, and the new `ExtendedRoute` mapped type re-types Route-returning helpers with a generic `this` parameter — so chains keep the full extension type, including across stacked `extend()` calls in any order.

Guardrails:

- An extension property that conflicts with an existing route member or an earlier extension throws a clear error. Inherited `Object.prototype` members (like `toString`) may be overridden; symbol keys are checked too.
- Deriving a route (`matching*`/`extend`) inside the extender body throws a clear error instead of recursing infinitely — extenders re-run for every derived route and must stay pure and synchronous (documented in the README).
- Extension properties are copied via property descriptors (accessors kept intact), an own `__proto__` key is rejected, and non-object/thenable extender results throw clear errors.
- `_derive` constructs via `this.constructor`, keeping the runtime class aligned with the `this` return type for Route subclasses.

## Backward compatibility

- Purely additive API: new `extend()` method and new exported types `ExtendedRoute` / `RouteExtender`.
- The `Route` constructor gains a trailing optional parameter.
- `matching*` return types changed `Route` → `this`, which only narrows the type (every `this` is a `Route`); all existing call sites keep compiling and runtime behavior of non-extended routes is unchanged.
- Verified by an independent audit: the new types are elided from the CJS output, dist typings use no newer TS features than already required, and the full pre-existing suite passes unmodified.

## Testing

- 8 mocha tests (`describe('extend')`): basic helper, chaining with built-ins (incl. object-form `matching`), stacked extends, immutability of the original route, name-collision errors (incl. `toString` override allowance), eager-derivation error, invalid extender results (null/async/`__proto__`), accessor preservation.
- Compile-time checks in `test/types/check.ts` for typed chaining, stacked extends in both orders, and the exported helper types.
- Full suite green: 47 mocha + 3 jest + type tests.

Version bumped to 8.6.0 — merging will auto-publish to npm.
